### PR TITLE
Cache json_schema in declarative streams

### DIFF
--- a/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
+++ b/airbyte-cdk/python/airbyte_cdk/sources/declarative/declarative_stream.py
@@ -3,6 +3,7 @@
 #
 
 from dataclasses import InitVar, dataclass, field
+from functools import lru_cache
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional, Union
 
 from airbyte_cdk.models import SyncMode
@@ -135,6 +136,7 @@ class DeclarativeStream(Stream):
             raise ValueError(f"DeclarativeStream does not support stream_slices that are not StreamSlice. Got {stream_slice}")
         yield from self.retriever.read_records(self.get_json_schema(), stream_slice)
 
+    @lru_cache(maxsize=None)
     def get_json_schema(self) -> Mapping[str, Any]:  # type: ignore
         """
         :return: A dict of the JSON schema representing this stream.


### PR DESCRIPTION
## What
Base stream class normally caches parsed json schema.
Method was overriden for declarative_stream and cache is missing. This causes massive performance impact.

## How
Add lru_cache to declarative stream, similar as in base stream class.

## Review guide
1. declarative_stream.py

## User Impact
Declarative streams get performance boost

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
